### PR TITLE
Update sendcoinsdialog.ui text

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -988,7 +988,7 @@
                      <item>
                       <widget class="QCheckBox" name="checkBoxMinimumFee">
                        <property name="toolTip">
-                        <string>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for litecoin transactions than the network can process.</string>
+                        <string>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for DeepOnion transactions than the network can process.</string>
                        </property>
                        <property name="text">
                         <string/>


### PR DESCRIPTION
When hovering mouse over transaction fee "Pay only the required fee of 0.00010000 ONION/kB ", the message displays "... demand for litecoin transactions ... ". 
I believe this should be "... demand for DeepOnion transactions ..." and made adjustment.