### PR TITLE
Allow wallet shutdown during LoadBlockIndex()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1519,6 +1519,11 @@ bool AppInitMain()
                 // Note that it also sets fReindex based on the disk flag!
                 // From here on out fReindex and fReset mean something different!
                 if (!LoadBlockIndex(chainparams)) {
+                    if (ShutdownRequested())
+                    {
+                        strLoadError = _("Closing Wallet");
+                        break;
+                    }
                     strLoadError = _("Error loading block database");
                     break;
                 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1519,11 +1519,7 @@ bool AppInitMain()
                 // Note that it also sets fReindex based on the disk flag!
                 // From here on out fReindex and fReset mean something different!
                 if (!LoadBlockIndex(chainparams)) {
-                    if (ShutdownRequested())
-                    {
-                        strLoadError = _("Closing Wallet");
-                        break;
-                    }
+                    if (ShutdownRequested()) break;
                     strLoadError = _("Error loading block database");
                     break;
                 }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -268,6 +268,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
     // Load mapBlockIndex
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
+        if (ShutdownRequested()) return false;
         std::pair<char, uint256> key;
         if (pcursor->GetKey(key) && key.first == DB_BLOCK_INDEX) {
             CDiskBlockIndex diskindex;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4172,6 +4172,8 @@ bool CChainState::LoadBlockIndex(const Consensus::Params& consensus_params, CBlo
     
     for (const std::pair<int, CBlockIndex*>& item : vSortedByHeight)
     {
+        if (ShutdownRequested()) return false;
+
         CBlockIndex* pindex = item.second;
         pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
         pindex->nTimeMax = (pindex->pprev ? std::max(pindex->pprev->nTimeMax, pindex->nTime) : pindex->nTime);


### PR DESCRIPTION
Lets you shuttdown the wallet while loadblockindex is running.