### PR TITLE
Update tor to version 0.4.0.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tor"]
 	path = tor
 	url = https://git.torproject.org/tor.git
-	branch = release-0.4.1
+	release = tor-0.4.0.5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tor"]
 	path = tor
 	url = https://git.torproject.org/tor.git
-	branch = 192c7c8bf9a3c53d32e83557ebc62cf7cfa3b1ca
+	branch = release-0.4.1

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -42,7 +42,7 @@ TOR_UTIL_LIBS = \
 	$(abs_top_builddir)/tor/src/lib/libtor-fdio.a \
 	$(abs_top_builddir)/tor/src/lib/libtor-string.a \
 	$(abs_top_builddir)/tor/src/lib/libtor-term.a \
-	$(abs_top_builddir)/tor/src/lib/libtor-smartlist-.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-smartlist-core.a \
 	$(abs_top_builddir)/tor/src/lib/libtor-malloc.a \
 	$(abs_top_builddir)/tor/src/lib/libtor-wallclock.a \
 	$(abs_top_builddir)/tor/src/lib/libtor-err.a \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,6 +23,54 @@ BITCOIN_INCLUDES=-I$(builddir) $(BDB_CPPFLAGS) $(BOOST_CPPFLAGS) $(LEVELDB_CPPFL
 BITCOIN_INCLUDES += -I$(srcdir)/secp256k1/include
 BITCOIN_INCLUDES += $(UNIVALUE_CFLAGS)
 
+TOR_UTIL_LIBS = \
+  tor/src/lib/libtor-geoip.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-process.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-time.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-fs.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-encoding.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-sandbox.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-container.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-net.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-thread.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-memarea.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-math.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-meminfo.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-osinfo.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-log.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-lock.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-fdio.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-string.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-term.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-smartlist-.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-malloc.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-wallclock.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-err.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-intmath.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-ctime.a
+
+LIBED25519_REF10 = $(abs_top_builddir)/tor/src/ext/ed25519/ref10/libed25519_ref10.a
+LIBED25519_DONNA = $(abs_top_builddir)/tor/src/ext/ed25519/donna/libed25519_donna.a
+LIBKECCAK_TINY = $(abs_top_builddir)/tor/src/ext/keccak-tiny/libkeccak-tiny.a
+LIBDONNA = $(abs_top_builddir)/tor/src/lib/libcurve25519_donna.a \
+  $(LIBED25519_REF10) \
+  $(LIBED25519_DONNA)
+
+TOR_CRYPTO_LIBS = \
+	tor/src/lib/libtor-tls.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-crypt-ops.a \
+	$(LIBKECCAK_TINY) \
+	$(LIBDONNA)
+
+TOR_LIBS = \
+	tor/src/core/libtor-app.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-compress.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-evloop.a \
+	$(abs_top_builddir)/$(TOR_CRYPTO_LIBS) \
+	$(abs_top_builddir)/$(TOR_UTIL_LIBS) \
+	$(abs_top_builddir)/tor/src/trunnel/libor-trunnel.a \
+	$(abs_top_builddir)/tor/src/lib/libtor-trace.a
+
 LIBBITCOIN_SERVER=libbitcoin_server.a
 LIBBITCOIN_COMMON=libbitcoin_common.a
 LIBBITCOIN_CONSENSUS=libbitcoin_consensus.a
@@ -447,16 +495,7 @@ DeepOniond_LDADD = \
   $(LIBSECP256K1)
 
 # Linking with Tor TODO: cap seccomp and z should be added using Autoconf really
-DeepOniond_LDADD += $(abs_top_builddir)/tor/src/or/libtor.a \
-        $(abs_top_builddir)/tor/src/common/libor.a \
-        $(abs_top_builddir)/tor/src/common/libor-ctime.a \
-        $(abs_top_builddir)/tor/src/common/libor-crypto.a \
-        $(abs_top_builddir)/tor/src/common/libor-event.a \
-        $(abs_top_builddir)/tor/src/trunnel/libor-trunnel.a \
-        $(abs_top_builddir)/tor/src/common/libcurve25519_donna.a \
-        $(abs_top_builddir)/tor/src/ext/ed25519/donna/libed25519_donna.a \
-        $(abs_top_builddir)/tor/src/ext/ed25519/ref10/libed25519_ref10.a \
-        $(abs_top_builddir)/tor/src/ext/keccak-tiny/libkeccak-tiny.a \
+DeepOniond_LDADD += $(abs_top_builddir)/$(TOR_LIBS) \
         $(LIBSECCOMP_LIBS) $(LIBCAP_LIBS) $(ZLIB_LIBS)
 
 DeepOniond_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(ZMQ_LIBS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,7 +47,13 @@ TOR_UTIL_LIBS = \
 	$(abs_top_builddir)/tor/src/lib/libtor-wallclock.a \
 	$(abs_top_builddir)/tor/src/lib/libtor-err.a \
 	$(abs_top_builddir)/tor/src/lib/libtor-intmath.a \
-	$(abs_top_builddir)/tor/src/lib/libtor-ctime.a
+        $(abs_top_builddir)/tor/src/lib/libtor-ctime.a \
+        $(abs_top_builddir)/tor/src/lib/libtor-version.a \
+        $(abs_top_builddir)/tor/src/lib/libtor-buf.a \
+        $(abs_top_builddir)/tor/src/lib/libtor-pubsub.a \
+        $(abs_top_builddir)/tor/src/lib/libtor-dispatch.a \
+        $(abs_top_builddir)/tor/src/lib/libtor-container.a
+
 
 LIBED25519_REF10 = $(abs_top_builddir)/tor/src/ext/ed25519/ref10/libed25519_ref10.a
 LIBED25519_DONNA = $(abs_top_builddir)/tor/src/ext/ed25519/donna/libed25519_donna.a
@@ -63,7 +69,7 @@ TOR_CRYPTO_LIBS = \
 	$(LIBDONNA)
 
 TOR_LIBS = \
-	tor/src/core/libtor-app.a \
+        $(abs_top_builddir)/tor/src/core/libtor-app.a \
 	$(abs_top_builddir)/tor/src/lib/libtor-compress.a \
 	$(abs_top_builddir)/tor/src/lib/libtor-evloop.a \
 	$(abs_top_builddir)/$(TOR_CRYPTO_LIBS) \
@@ -495,7 +501,7 @@ DeepOniond_LDADD = \
   $(LIBSECP256K1)
 
 # Linking with Tor TODO: cap seccomp and z should be added using Autoconf really
-DeepOniond_LDADD += $(abs_top_builddir)/$(TOR_LIBS) \
+DeepOniond_LDADD += $(TOR_LIBS) \
         $(LIBSECCOMP_LIBS) $(LIBCAP_LIBS) $(ZLIB_LIBS)
 
 DeepOniond_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(ZMQ_LIBS)

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -46,16 +46,7 @@ bench_bench_DeepOnion_LDADD = \
   $(LIBUNIVALUE)
 
 # Linking with Tor TODO: cap seccomp and z should be added using Autoconf really
-bench_bench_DeepOnion_LDADD += $(abs_top_builddir)/tor/src/or/libtor.a \
-        $(abs_top_builddir)/tor/src/common/libor.a \
-        $(abs_top_builddir)/tor/src/common/libor-ctime.a \
-        $(abs_top_builddir)/tor/src/common/libor-crypto.a \
-        $(abs_top_builddir)/tor/src/common/libor-event.a \
-        $(abs_top_builddir)/tor/src/trunnel/libor-trunnel.a \
-        $(abs_top_builddir)/tor/src/common/libcurve25519_donna.a \
-        $(abs_top_builddir)/tor/src/ext/ed25519/donna/libed25519_donna.a \
-        $(abs_top_builddir)/tor/src/ext/ed25519/ref10/libed25519_ref10.a \
-        $(abs_top_builddir)/tor/src/ext/keccak-tiny/libkeccak-tiny.a \
+bench_bench_DeepOnion_LDADD += $(TOR_LIBS) \
         $(LIBSECCOMP_LIBS) $(LIBCAP_LIBS) $(ZLIB_LIBS)
 
 if ENABLE_ZMQ

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -550,17 +550,7 @@ if ENABLE_ZMQ
 qt_DeepOnion_qt_LDADD += $(LIBBITCOIN_ZMQ) $(ZMQ_LIBS)
 endif
 qt_DeepOnion_qt_LDADD += $(LIBBITCOIN_CLI) $(LIBBITCOIN_COMMON) $(LIBBITCOIN_UTIL) $(LIBBITCOIN_CONSENSUS) $(LIBBITCOIN_CRYPTO) $(LIBUNIVALUE) $(LIBLEVELDB) $(LIBLEVELDB_SSE42) $(LIBMEMENV) \
-  $(BOOST_LIBS) $(QT_LIBS) $(QT_DBUS_LIBS) $(QR_LIBS) $(PROTOBUF_LIBS) $(BDB_LIBS) \
-  $(abs_top_builddir)/tor/src/or/libtor.a \
-  $(abs_top_builddir)/tor/src/common/libor.a \
-  $(abs_top_builddir)/tor/src/common/libor-ctime.a \
-  $(abs_top_builddir)/tor/src/common/libor-crypto.a \
-  $(abs_top_builddir)/tor/src/common/libor-event.a \
-  $(abs_top_builddir)/tor/src/trunnel/libor-trunnel.a \
-  $(abs_top_builddir)/tor/src/common/libcurve25519_donna.a \
-  $(abs_top_builddir)/tor/src/ext/ed25519/donna/libed25519_donna.a \
-  $(abs_top_builddir)/tor/src/ext/ed25519/ref10/libed25519_ref10.a \
-  $(abs_top_builddir)/tor/src/ext/keccak-tiny/libkeccak-tiny.a \
+  $(BOOST_LIBS) $(QT_LIBS) $(QT_DBUS_LIBS) $(QR_LIBS) $(PROTOBUF_LIBS) $(BDB_LIBS) $(TOR_LIBS) \
   $(LIBSECCOMP_LIBS) $(LIBCAP_LIBS) $(ZLIB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(LIBSECP256K1) \
   $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS)
 qt_DeepOnion_qt_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(QT_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)


### PR DESCRIPTION
Tor release from May 2, 2019. 

  This is the first stable release in the 0.4.0.x series. It contains  improvements for power management and bootstrap reporting, as well as  preliminary backend support for circuit padding to prevent some kinds  of traffic analysis. It also continues our work in refactoring Tor for  long-term maintainability.