### PR TITLE
Update modaloverlay.ui

### DIFF
--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -81,7 +81,7 @@
                 <bool>false</bool>
                </property>
                <property name="text">
-                <string/>
+               
                </property>
                <property name="iconSize">
                 <size>


### PR DESCRIPTION
line was <string/> . That looked strange to me. I am not an expert so maybe it's there for a reason (a hack maybe?) but I could find no matching <string> and the slash "/" after the command seems out of place. I hope I did this correctly.