### PR TITLE
Fix macOS notifications

### DIFF
--- a/src/qt/macnotificationhandler.mm
+++ b/src/qt/macnotificationhandler.mm
@@ -13,7 +13,7 @@
 - (NSString *)__bundleIdentifier
 {
     if (self == [NSBundle mainBundle]) {
-        return @"org.bitcoinfoundation.Bitcoin-Qt";
+        return @"org.deeponion.DeepOnion-Qt";
     } else {
         return [self __bundleIdentifier];
     }


### PR DESCRIPTION
Hi,

This PR addresses a minor yet important issue regarding the **macOS notification handler**'s bundle identifier. Previously, the identifier was the same as for Bitcoin's Core wallet, which could lead to collisions when both Bitcoin and DeepOnion clients were installed on the same machine. In such cases, notifications for new transactions would incorrectly display the Bitcoin icon instead of the DeepOnion icon.

![Screenshot 2023-11-28 at 12 19 03](https://github.com/deeponion/deeponion/assets/56779/96283f1c-2aa7-4efb-b509-9bd2bb996e5b)

The change involves renaming the identifier from `org.bitcoinfoundation.Bitcoin-Qt` to `org.deeponion.DeepOnion-Qt`. This modification ensures that notifications from the DeepOnion client display the correct icon, avoiding confusion for users who have both clients installed.

![Screenshot 2023-11-28 at 12 18 53](https://github.com/deeponion/deeponion/assets/56779/709a19e4-019f-4fe1-aeaf-bf0118119d27)

Best regards,
Harris