### PR TITLE
Fix macOS build

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -24,3 +24,5 @@ cd "${srcdir}/src/secp256k1"
 ./autogen.sh
 cd "${srcdir}/tor"
 ./autogen.sh
+cd "${srcdir}"
+

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,19 +1,26 @@
-#!/bin/sh
-# Copyright (c) 2013-2016 The Bitcoin Core developers
+#!/bin/bash
+# Copyright (c) 2013 - 2016 The Bitcoin Core developers
+# Copyright (c) 2017 - 2023 The DeepOnion developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+export LC_ALL=C
+
+srcdir=`pwd`
+
 set -e
-srcdir="$(dirname $0)"
-cd "$srcdir"
-if [ -z "${LIBTOOLIZE}" ] && GLIBTOOLIZE="$(command -v glibtoolize)"; then
+git submodule update --init --recursive
+
+if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="`command -v glibtoolize 2>/dev/null`"; then
   LIBTOOLIZE="${GLIBTOOLIZE}"
   export LIBTOOLIZE
 fi
-which autoreconf >/dev/null || \
+command -v autoreconf >/dev/null || \
   (echo "configuration failed, please install autoconf first" && exit 1)
 autoreconf --install --force --warnings=all
 
-cd tor
+echo "Configure subtrees (secp256k1 and tor)"
+cd "${srcdir}/src/secp256k1"
 ./autogen.sh
-cd ..
+cd "${srcdir}/tor"
+./autogen.sh

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl require autoconf 2.60 (AS_ECHO/AS_ECHO_N)
-AC_PREREQ([2.60])
+AC_PREREQ([2.71])
 define(_CLIENT_VERSION_MAJOR, 2)
 define(_CLIENT_VERSION_MINOR, 3)
 define(_CLIENT_VERSION_REVISION, 4)
@@ -15,7 +15,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
 # This is the original line, the modified uncommented line removes reported errors. Just leaving in so we have a history in GIT. TODO: Remove commented line
 #AX_SUBDIRS_CONFIGURE([tor], [[--disable-unittests], [--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-asciidoc], [--with-openssl-dir=$($PKG_CONFIG --variable=libdir openssl)], [CFLAGS=$($PKG_CONFIG --cflags openssl) -fPIC -O2]])
-AX_SUBDIRS_CONFIGURE([tor], [[--disable-zstd], [--disable-unittests], [--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-asciidoc], [--with-openssl-dir=$($PKG_CONFIG openssl)], [CFLAGS=$($PKG_CONFIG --cflags openssl) -fPIC -O2]])
+#AX_SUBDIRS_CONFIGURE([tor], [[--disable-zstd], [--disable-unittests], [--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-asciidoc]])
 
 
 BITCOIN_DAEMON_NAME=DeepOniond
@@ -1024,7 +1024,7 @@ CXXFLAGS="${CXXFLAGS} ${CRYPTO_CFLAGS} ${SSL_CFLAGS}"
 AC_CHECK_DECLS([EVP_MD_CTX_new],,,[AC_INCLUDES_DEFAULT
 #include <openssl/x509_vfy.h>
 ])
-CXXFLAGS="${save_CXXFLAGS}"
+CXXFLAGS="${save_CXXFLAGS} -Wno-enum-constexpr-conversion"
 
 dnl univalue check
 
@@ -1320,8 +1320,13 @@ if test x$need_bundled_univalue = xyes; then
   AC_CONFIG_SUBDIRS([src/univalue])
 fi
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no --enable-module-recovery --disable-jni"
-AC_CONFIG_SUBDIRS([src/secp256k1])
+#ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no --enable-module-recovery --disable-jni"
+#AC_CONFIG_SUBDIRS([src/secp256k1])
+
+AX_SUBDIRS_CONFIGURE([src/secp256k1], [[--disable-shared], [--with-pic], [--with-bignum=no], [--enable-module-recovery], [--enable-experimental], [--enable-module-ecdh]])
+
+ac_configure_args="${ac_configure_args} --disable-shared --disable-gcc-hardening --with-pic --with-bignum=no --enable-module-recovery --disable-jni --disable-system-torrc --disable-systemd --disable-lzma --disable-zstd --disable-asciidoc"
+AC_CONFIG_SUBDIRS([tor])
 
 AC_OUTPUT
 
@@ -1366,9 +1371,9 @@ echo "  build os      = $BUILD_OS"
 echo
 echo "  CC            = $CC"
 echo "  CFLAGS        = $CFLAGS"
-echo "  CPPFLAGS      = $CPPFLAGS"
+echo "  CPPFLAGS      = $DEBUG_CPPFLAGS $HARDENED_CPPFLAGS $CPPFLAGS"
 echo "  CXX           = $CXX"
-echo "  CXXFLAGS      = $CXXFLAGS"
-echo "  LDFLAGS       = $LDFLAGS"
+echo "  CXXFLAGS      = $DEBUG_CXXFLAGS $HARDENED_CXXFLAGS $WARN_CXXFLAGS $NOWARN_CXXFLAGS $ERROR_CXXFLAGS $GPROF_CXXFLAGS $CXXFLAGS"
+echo "  LDFLAGS       = $PTHREAD_CFLAGS $HARDENED_LDFLAGS $GPROF_LDFLAGS $LDFLAGS"
 echo "  ARFLAGS       = $ARFLAGS"
 echo

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl require autoconf 2.60 (AS_ECHO/AS_ECHO_N)
-AC_PREREQ([2.71])
+AC_PREREQ([2.60])
 define(_CLIENT_VERSION_MAJOR, 2)
 define(_CLIENT_VERSION_MINOR, 3)
 define(_CLIENT_VERSION_REVISION, 4)
@@ -15,7 +15,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
 # This is the original line, the modified uncommented line removes reported errors. Just leaving in so we have a history in GIT. TODO: Remove commented line
 #AX_SUBDIRS_CONFIGURE([tor], [[--disable-unittests], [--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-asciidoc], [--with-openssl-dir=$($PKG_CONFIG --variable=libdir openssl)], [CFLAGS=$($PKG_CONFIG --cflags openssl) -fPIC -O2]])
-#AX_SUBDIRS_CONFIGURE([tor], [[--disable-zstd], [--disable-unittests], [--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-asciidoc]])
+AX_SUBDIRS_CONFIGURE([tor], [[--disable-zstd], [--disable-unittests], [--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-asciidoc]])
 
 
 BITCOIN_DAEMON_NAME=DeepOniond
@@ -1320,13 +1320,8 @@ if test x$need_bundled_univalue = xyes; then
   AC_CONFIG_SUBDIRS([src/univalue])
 fi
 
-#ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no --enable-module-recovery --disable-jni"
-#AC_CONFIG_SUBDIRS([src/secp256k1])
-
-AX_SUBDIRS_CONFIGURE([src/secp256k1], [[--disable-shared], [--with-pic], [--with-bignum=no], [--enable-module-recovery], [--enable-experimental], [--enable-module-ecdh]])
-
-ac_configure_args="${ac_configure_args} --disable-shared --disable-gcc-hardening --with-pic --with-bignum=no --enable-module-recovery --disable-jni --disable-system-torrc --disable-systemd --disable-lzma --disable-zstd --disable-asciidoc"
-AC_CONFIG_SUBDIRS([tor])
+ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no --enable-module-recovery --disable-jni"
+AC_CONFIG_SUBDIRS([src/secp256k1])
 
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
 # This is the original line, the modified uncommented line removes reported errors. Just leaving in so we have a history in GIT. TODO: Remove commented line
 #AX_SUBDIRS_CONFIGURE([tor], [[--disable-unittests], [--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-asciidoc], [--with-openssl-dir=$($PKG_CONFIG --variable=libdir openssl)], [CFLAGS=$($PKG_CONFIG --cflags openssl) -fPIC -O2]])
-AX_SUBDIRS_CONFIGURE([tor], [[--disable-zstd], [--disable-unittests], [--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-asciidoc]])
+AX_SUBDIRS_CONFIGURE([tor], [[--disable-zstd], [--disable-gcc-hardening], [--disable-unittests], [--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-asciidoc]])
 
 
 BITCOIN_DAEMON_NAME=DeepOniond

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -36,7 +36,7 @@
 #include <QMessageBox>
 #include <QSet>
 #include <QTimer>
-
+#include <random>
 
 WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *_wallet, OptionsModel *_optionsModel, QObject *parent) :
     QObject(parent), wallet(_wallet), optionsModel(_optionsModel), addressTableModel(0),
@@ -319,7 +319,9 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                 vecSend.push_back(recipient2);
 
                 // -- shuffle inputs, change output won't mix enough as it must be not fully random for plantext narrations
-                std::random_shuffle(vecSend.begin(), vecSend.end());
+                std::random_device rd;
+                std::mt19937 g(rd());
+                std::shuffle(vecSend.begin(), vecSend.end(), g);
 
                 fStealthAddressAdded = true;
             }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -35,6 +35,7 @@
 #include <stdint.h>
 
 #include <univalue.h>
+#include <random>
 
 static const std::string WALLET_ENDPOINT_BASE = "/wallet/";
 
@@ -3911,7 +3912,9 @@ static void SendStealthMoney(CWallet * const pwallet, CStealthAddress& sxAddress
     vecSend.push_back(recipient2);
 
     // -- shuffle inputs, change output won't mix enough as it must be not fully random for plantext narrations
-    std::random_shuffle(vecSend.begin(), vecSend.end());
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(vecSend.begin(), vecSend.end(), g);
 
     bool rv = pwallet->CreateTransaction(vecSend, wtxNew, reservekey, nFeeRequired, nChangePosRet, strError, coin_control);
     if (!rv) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -39,6 +39,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
+#include <random>
 
 // DeepOnion: PoS Port
 unsigned int nStakeSplitAge = 20 * 24 * 60 * 60;
@@ -2639,7 +2640,9 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
     std::vector<CInputCoin> vValue;
     CAmount nTotalLower = 0;
 
-    random_shuffle(vCoins.begin(), vCoins.end(), GetRandInt);
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(vCoins.begin(), vCoins.end(), g);
 
     for (const COutput &output : vCoins)
     {


### PR DESCRIPTION
This PR introduces several changes essential for successful compilation on macOS (Intel x64):

1. Replaced the now-obsolete `std::random_shuffle` with `std::shuffle`. `std::random_shuffle` was deprecated in C++14 and completely removed in C++17. Since the DeepOnion wallet requires C++17 for **protobuf** compilation, we must use `std::shuffle`, which is a better alternative due to its superior randomness generator. Further information can be found here: [https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4190.htm](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4190.htm).

2. `autogen.sh` is now configured to handle both "tor" and "secp256k1" subprojects.

3. Enabled enum constexpr conversion using the `-Wno-enum-constexpr-conversion` flag in `configure.ac`.

These modifications do not adversely impact Win32 builds. Additionally, a separate Windows build using WSL2 was successfully executed with these changes.
